### PR TITLE
Ensure the Labels knows about it's fonts

### DIFF
--- a/Artsy+OSSUIFonts/1.1.0/Artsy+OSSUIFonts.podspec
+++ b/Artsy+OSSUIFonts/1.1.0/Artsy+OSSUIFonts.podspec
@@ -16,4 +16,5 @@ Pod::Spec.new do |s|
 
   s.frameworks = 'UIKit', 'CoreText'
   s.module_name = 'Artsy_UIFonts'
+  s.deprecated_in_favor_of = 'Artsy+UIFonts'
 end

--- a/Artsy+UILabels/2.0.1/Artsy+UILabels.podspec
+++ b/Artsy+UILabels/2.0.1/Artsy+UILabels.podspec
@@ -1,0 +1,19 @@
+Pod::Spec.new do |s|
+  s.name             = "Artsy+UILabels"
+  s.version          = "2.0.1"
+  s.summary          = "UILabels subclasses and related categories."
+  s.homepage         = "https://github.com/artsy/Artsy-UILabels"
+  s.license          = 'MIT'
+  s.author           = { "Orta" => "orta.therox@gmail.com" }
+  s.source           = { :git => "https://github.com/artsy/Artsy-UILabels.git", :tag => s.version.to_s }
+  s.social_media_url = 'https://twitter.com/artsyopensource'
+
+  s.platform     = :ios, '7.0'
+
+  s.source_files = 'Pod/Classes'
+  s.resources = 'Pod/Assets/*.png'
+
+  s.frameworks = 'UIKit'
+  s.dependency 'Artsy+UIColors', '~> 3.0'
+  s.dependency 'Artsy+UIFonts'
+end


### PR DESCRIPTION
CP 1.0 "removes" weak-linking between pods ( it was an implementation detail. ) 

This means the labels now specifically says that it includes fonts. I also deprecated the OSSUIFonts - as it won't work with CP 1.0
